### PR TITLE
Digitizer trigger timeout fixed by using send_scpi_cmd

### DIFF
--- a/Notebooks/Working with Digitizer/DigitizerInternalTrigger.ipynb
+++ b/Notebooks/Working with Digitizer/DigitizerInternalTrigger.ipynb
@@ -274,7 +274,7 @@
     "inst.send_scpi_cmd(':DIG:INIT ON')\n",
     "# Generate 4 software-triggers\n",
     "for _ in range(capture_count):\n",
-    "    inst.send_scpi_query(':DIG:TRIG:IMM')\n",
+    "    inst.send_scpi_cmd(':DIG:TRIG:IMM')\n",
     "    time.sleep(0.1) # more than  enough for capturing single frame\n",
     "    # Query the status\n",
     "    resp = inst.send_scpi_query(\":DIG:ACQuire:FRAM:STATus?\")\n",


### PR DESCRIPTION
inst.send_scpi_query(':DIG:TRIG:IMM') times out, probably because the instrument is expecting either a '?' or we are waiting for a response. Updated to inst.send_scpi_cmd(':DIG:TRIG:IMM').